### PR TITLE
Fix broken tests after dependency updates

### DIFF
--- a/src/lib/db/migrations/001_create_tables.ts
+++ b/src/lib/db/migrations/001_create_tables.ts
@@ -24,7 +24,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
 			  AND active = 1
 		)
 		BEGIN
-			SELECT RAISE(FAIL, "Another active goal with the same orderNumber exists.");
+			SELECT RAISE(FAIL, 'Another active goal with the same orderNumber exists.');
 		END;
 	`.execute(db);
 


### PR DESCRIPTION
Fixes "no such column" errors by correcting a string literal in a SQLite trigger.

Recent dependency updates led to SQLite interpreting an unquoted error message string within a trigger as a column name, causing `SqliteError: no such column: "Another active goal with the same orderNumber exists."` failures across numerous tests. This change properly quotes the string to ensure it's treated as a literal message.

---
<a href="https://cursor.com/background-agent?bcId=bc-e14e31e5-834d-479b-afae-1870b9d5253e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e14e31e5-834d-479b-afae-1870b9d5253e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Correctly quote the SQLite trigger error message in `src/lib/db/migrations/001_create_tables.ts` to be a string literal instead of an identifier.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4962dc906f7d9419f72629f155f1faa3f8e6e229. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->