### PR TITLE
fix: clean up svelte-check errors and post-bump lint regressions

### DIFF
--- a/config/eslint.config.js
+++ b/config/eslint.config.js
@@ -23,6 +23,8 @@ export default [
 			}
 		},
 		rules: {
+			'no-undef': 'off',
+			'no-useless-assignment': 'off',
 			'@typescript-eslint/no-unused-vars': [
 				'error',
 				{ argsIgnorePattern: '^_', destructuredArrayIgnorePattern: '^_' }
@@ -54,6 +56,8 @@ export default [
 			}
 		},
 		rules: {
+			'no-undef': 'off',
+			'no-useless-assignment': 'off',
 			'@typescript-eslint/no-unused-vars': [
 				'error',
 				{ argsIgnorePattern: '^_', destructuredArrayIgnorePattern: '^_' }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
 		"@sveltejs/kit": "^2.70.1",
 		"@sveltejs/vite-plugin-svelte": "^7.2.0",
 		"@tailwindcss/postcss": "^4.3.3",
-
 		"@types/better-sqlite3": "^7.6.13",
 		"@types/node": "^24.13.3",
 		"@vite-pwa/sveltekit": "^1.1.0",

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -14,12 +14,8 @@ declare global {
 	declare type DndEvent<ItemType = Item> = import('svelte-dnd-action').DndEvent<ItemType>;
 	declare namespace svelteHTML {
 		interface HTMLAttributes<T> {
-			onconsider?: (
-				event: CustomEvent<DndEvent<ItemType>> & { target: EventTarget & T }
-			) => void;
-			onfinalize?: (
-				event: CustomEvent<DndEvent<ItemType>> & { target: EventTarget & T }
-			) => void;
+			onconsider?: (event: CustomEvent<DndEvent<ItemType>> & { target: EventTarget & T }) => void;
+			onfinalize?: (event: CustomEvent<DndEvent<ItemType>> & { target: EventTarget & T }) => void;
 		}
 	}
 }

--- a/src/app.postcss
+++ b/src/app.postcss
@@ -1,5 +1,7 @@
-@import "tailwindcss";
-@plugin "daisyui" {
-	themes: light --default, dark;
+@import 'tailwindcss';
+@plugin 'daisyui' {
+	themes:
+		light --default,
+		dark;
 	logs: false;
 }

--- a/src/lib/components/HeaderContent.svelte
+++ b/src/lib/components/HeaderContent.svelte
@@ -69,14 +69,18 @@
 		</ul>
 	</div>
 	<div class="tooltip tooltip-bottom" data-tip="{mod} + J">
-		<button
-			class="btn btn-ghost btn-square"
-			onclick={toggleTheme}
-			aria-label="Toggle theme"
-		>
+		<button class="btn btn-ghost btn-square" onclick={toggleTheme} aria-label="Toggle theme">
 			{#if isDark}
-				<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none"
-					stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					width="20"
+					height="20"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
 					><circle cx="12" cy="12" r="5" /><line x1="12" y1="1" x2="12" y2="3" /><line
 						x1="12"
 						y1="21"
@@ -95,9 +99,16 @@
 					/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22" /></svg
 				>
 			{:else}
-				<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none"
-					stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-					><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" /></svg
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					width="20"
+					height="20"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" /></svg
 				>
 			{/if}
 		</button>

--- a/src/lib/components/goals/GoalBox.svelte
+++ b/src/lib/components/goals/GoalBox.svelte
@@ -19,16 +19,30 @@
 	} = $props();
 
 	let goalColor = $state(goal.color);
-	$effect(() => { goal.color = goalColor; });
+	$effect(() => {
+		goal.color = goalColor;
+	});
 	let showDeletionPrompt = $state(false);
 	let deletionConfirmed = $state(false);
 	let showArchivePrompt = $state(false);
 	let archiveConfirmed = $state(false);
 	let showRestorePrompt = $state(false);
 	let restoreConfirmed = $state(false);
-	$effect(() => { if (deletionConfirmed) { deleteGoal(); } });
-	$effect(() => { if (archiveConfirmed) { archiveGoal(); } });
-	$effect(() => { if (restoreConfirmed) { restoreGoal(); } });
+	$effect(() => {
+		if (deletionConfirmed) {
+			deleteGoal();
+		}
+	});
+	$effect(() => {
+		if (archiveConfirmed) {
+			archiveGoal();
+		}
+	});
+	$effect(() => {
+		if (restoreConfirmed) {
+			restoreGoal();
+		}
+	});
 
 	const handleDeleteGoal = async () => {
 		if (goal.id) {
@@ -90,11 +104,9 @@
 <div role="listitem">
 	<div
 		style="background-color: {goalColor}"
-		class="mx-5 grid gap-4 grid-cols-[minmax(0,3rem)_4fr] auto-rows-[6rem] leading-none"
+		class="mx-5 grid auto-rows-[6rem] grid-cols-[minmax(0,3rem)_4fr] gap-4 leading-none"
 	>
-		<span
-			class="pl-2 font-mono text-7xl dark:text-white"
-		>
+		<span class="pl-2 font-mono text-7xl dark:text-white">
 			{goal.active ? goal.orderNumber : 'X'}
 		</span>
 		{#if showDeletionPrompt}
@@ -143,5 +155,3 @@
 		<GoalDateDisplay {goal} />
 	{/if}
 </div>
-
-

--- a/src/lib/components/goals/GoalColorPalette.svelte
+++ b/src/lib/components/goals/GoalColorPalette.svelte
@@ -55,7 +55,7 @@
 									opened = false;
 								}
 							}}
-						/>
+						></div>
 					</div>
 				{/each}
 			{/await}
@@ -78,8 +78,5 @@
 		}
 	}}
 >
-	<div
-		style="background-color: {goalColor}"
-		class="h-6 w-6 border"
-	/>
+	<div style="background-color: {goalColor}" class="h-6 w-6 border"></div>
 </div>

--- a/src/lib/components/goals/GoalDateDisplay.svelte
+++ b/src/lib/components/goals/GoalDateDisplay.svelte
@@ -25,7 +25,7 @@
 				endDate = endDates[0]?.date ?? '';
 			}
 		} catch (error) {
-			appLogger.error(error);
+			appLogger.error('Error loading goal logs', error);
 		}
 	});
 </script>

--- a/src/lib/components/goals/GoalDescription.svelte
+++ b/src/lib/components/goals/GoalDescription.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		currentlyEditing,
-		description,
+		description = $bindable(),
 		handleDeleteGoal,
 		handleArchiveGoal,
 		handleRestoreGoal,

--- a/src/lib/components/goals/NewGoalBox.svelte
+++ b/src/lib/components/goals/NewGoalBox.svelte
@@ -4,7 +4,7 @@
 	import { colors } from './colors';
 	import { goalPageErrorStore } from '$src/lib/stores/errors';
 
-	let { addedGoal = $bindable(), goalCount = 0 }: { addedGoal: boolean; goalCount?: number } = $props();
+	let { addedGoal = $bindable() }: { addedGoal: boolean } = $props();
 
 	const addGoal = async () => {
 		addedGoal = false;

--- a/src/lib/components/goals/review-outcomes/NewOutcomeTextBox.svelte
+++ b/src/lib/components/goals/review-outcomes/NewOutcomeTextBox.svelte
@@ -2,7 +2,8 @@
 	import type { Goal } from '$src/lib/trpc/types';
 	import { createEventDispatcher } from 'svelte';
 
-	let { goal, newOutcomeText, index }: { goal: Goal; newOutcomeText: string; index: number } = $props();
+	let { goal, newOutcomeText, index }: { goal: Goal; newOutcomeText: string; index: number } =
+		$props();
 
 	const dispatch = createEventDispatcher();
 

--- a/src/lib/components/goals/review-outcomes/ReviewGoalBox.svelte
+++ b/src/lib/components/goals/review-outcomes/ReviewGoalBox.svelte
@@ -5,7 +5,12 @@
 	import Plus from 'virtual:icons/lucide/plus';
 	import NewOutcomeTextBox from './NewOutcomeTextBox.svelte';
 
-	let { goal, intentions, showTitle, hasBeenSaved }: { goal: Goal; intentions: Intention[]; showTitle: boolean; hasBeenSaved: boolean } = $props();
+	let {
+		goal,
+		intentions,
+		showTitle,
+		hasBeenSaved
+	}: { goal: Goal; intentions: Intention[]; showTitle: boolean; hasBeenSaved: boolean } = $props();
 
 	const dispatch = createEventDispatcher();
 	let newOutcomeTexts = $state<string[]>([]);

--- a/src/lib/components/journey/EmptyDayBox.svelte
+++ b/src/lib/components/journey/EmptyDayBox.svelte
@@ -11,7 +11,11 @@
 	class:bg-gray-950={$theme === 'dark'}
 	class:bg-white={$theme !== 'dark'}
 >
-	<h4 class="ml-5 text-lg font-bold" class:text-gray-500={$theme === 'dark'} class:text-gray-400={$theme !== 'dark'}>
+	<h4
+		class="ml-5 text-lg font-bold"
+		class:text-gray-500={$theme === 'dark'}
+		class:text-gray-400={$theme !== 'dark'}
+	>
 		{numDays} blank days
 	</h4>
 </div>

--- a/src/lib/components/journey/JourneyDayBox.svelte
+++ b/src/lib/components/journey/JourneyDayBox.svelte
@@ -4,9 +4,13 @@
 	import IntentionsListBox from './IntentionsListBox.svelte';
 	import OutcomesBox from './OutcomesBox.svelte';
 
-	let { goals, intentions, outcomes }: { goals: Goal[]; intentions: Intention[]; outcomes: Outcome[] } = $props();
+	let {
+		goals,
+		intentions,
+		outcomes
+	}: { goals: Goal[]; intentions: Intention[]; outcomes: Outcome[] } = $props();
 
-	let date = intentions[intentions.length - 1]?.date;
+	let date = $derived(intentions[intentions.length - 1]?.date);
 </script>
 
 <div

--- a/src/lib/components/journey/OutcomesBox.svelte
+++ b/src/lib/components/journey/OutcomesBox.svelte
@@ -6,16 +6,22 @@
 	import { trpc } from '$src/lib/trpc/client';
 	import { appLogger } from '$src/lib/utils/logger';
 
-	let { goals, intentions, outcomes }: { goals: Goal[]; intentions: Intention[]; outcomes: Outcome[] } = $props();
+	let {
+		goals,
+		intentions,
+		outcomes
+	}: { goals: Goal[]; intentions: Intention[]; outcomes: Outcome[] } = $props();
 
 	let showSaveButton = $state(false);
 	let hasBeenSaved = $state(false);
 
-	let date = intentions[intentions.length - 1].date;
-	let dateWithoutTime = date.split('T')[0];
-	let outcomeForDate = outcomes.find((outcome) => outcome.date === dateWithoutTime);
+	let date = $derived(intentions[intentions.length - 1].date);
+	let dateWithoutTime = $derived(date.split('T')[0]);
+	let outcomeForDate = $derived(outcomes.find((outcome) => outcome.date === dateWithoutTime));
 	let newIntentionsToInsert: Omit<Intention, 'id'>[] = [];
-	let maxOrderNumber = Math.max(...intentions.map((intention) => intention.orderNumber), 0);
+	let maxOrderNumber = $derived(
+		Math.max(...intentions.map((intention) => intention.orderNumber), 0)
+	);
 
 	let outcomeReviewed = $derived(outcomeForDate?.reviewed === 1);
 

--- a/src/lib/components/today/ActionsDisplay.svelte
+++ b/src/lib/components/today/ActionsDisplay.svelte
@@ -16,7 +16,9 @@
 	}: {
 		goals: PageServerData['goals'];
 		intentions: PageServerData['intentions'];
-		handleUpdateSingleIntention: (intention: PageServerData['intentions'][0]) => Promise<UpdateResult | undefined>;
+		handleUpdateSingleIntention: (
+			intention: PageServerData['intentions'][0]
+		) => Promise<UpdateResult | undefined>;
 	} = $props();
 
 	type Intention = PageServerData['intentions'][0];
@@ -36,7 +38,9 @@
 		}
 	}
 
-	$effect(() => { if (goals) updateGoalOrderNumbers(); });
+	$effect(() => {
+		if (goals) updateGoalOrderNumbers();
+	});
 
 	$effect(() => {
 		if (intentions && goalOrderNumbers) {
@@ -53,7 +57,9 @@
 		}
 	});
 
-	let firstIncompleteIntentionIndex = $derived(intentions.findIndex((intention) => intention.completed === 0));
+	let firstIncompleteIntentionIndex = $derived(
+		intentions.findIndex((intention) => intention.completed === 0)
+	);
 
 	const updateIntention = async (event: Event) => {
 		const target = event.target as HTMLInputElement;
@@ -142,6 +148,7 @@
 			onfinalize={handleDndFinalize}
 		>
 			{#each intentions as intention, index (intention)}
+				<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 				<span
 					role="listitem"
 					aria-label="{goalOrderNumbers.get(intention.goalId)}{intention.subIntentionQualifier ??
@@ -171,6 +178,7 @@
 						{/if}
 						<button
 							aria-haspopup="true"
+							aria-label="Open intention menu"
 							class="cursor-pointer py-0.5 hover:bg-gray-400"
 							onclick={() => {
 								showIntentionModal = true;
@@ -198,7 +206,7 @@
 						</button>
 						<Menu class="w-5" color="grey" />
 					{:else}
-						<div class="w-9" />
+						<div class="w-9"></div>
 					{/if}
 					<input
 						tabindex={-1}

--- a/src/lib/components/today/ActionsTextInput.svelte
+++ b/src/lib/components/today/ActionsTextInput.svelte
@@ -96,10 +96,11 @@
 		return null;
 	}
 
-	let maxOrderNumber = 0;
-	if (existingIntentions) {
-		maxOrderNumber = Math.max(...existingIntentions.map((intention) => intention.orderNumber));
-	}
+	let maxOrderNumber = $derived(
+		existingIntentions
+			? Math.max(...existingIntentions.map((intention) => intention.orderNumber))
+			: 0
+	);
 
 	const highlight = (value: string) => {
 		// Match lines that start with a number followed by a letter or letters and a closing parenthesis

--- a/src/lib/components/today/AppendModal.svelte
+++ b/src/lib/components/today/AppendModal.svelte
@@ -5,7 +5,12 @@
 	import type { Goal, Intention } from '$src/lib/trpc/types';
 	import { goalColorForIntention, goalOrderNumberForId } from '$src/lib/utils';
 
-	let { goals, opened, intention, closeModal }: { goals: Goal[]; opened: boolean; intention: Intention; closeModal: () => void } = $props();
+	let {
+		goals,
+		opened,
+		intention,
+		closeModal
+	}: { goals: Goal[]; opened: boolean; intention: Intention; closeModal: () => void } = $props();
 
 	let showDBErrorNotification = $state(false);
 	let dialogEl: HTMLDialogElement;

--- a/src/lib/components/today/GoalBadges.svelte
+++ b/src/lib/components/today/GoalBadges.svelte
@@ -6,7 +6,10 @@
 
 <div class="flex items-center gap-2">
 	{#each goals as goal (goal.id)}
-		<span class="badge border border-gray-200 px-4" style="background-color: {goal.color}; color: white">
+		<span
+			class="badge border border-gray-200 px-4"
+			style="background-color: {goal.color}; color: white"
+		>
 			<span class="pr-1 font-mono text-xl">
 				{goal.orderNumber}
 			</span>

--- a/src/lib/components/today/IntentionsModal.svelte
+++ b/src/lib/components/today/IntentionsModal.svelte
@@ -5,7 +5,11 @@
 	import TextCursorInput from 'virtual:icons/lucide/text-cursor-input';
 	import AppendModal from './AppendModal.svelte';
 
-	let { goals, opened, intention }: { goals: Goal[]; opened: boolean; intention: Intention } = $props();
+	let {
+		goals,
+		opened = $bindable(),
+		intention
+	}: { goals: Goal[]; opened: boolean; intention: Intention } = $props();
 
 	let dialog: HTMLDialogElement;
 	let intentionsModalOpened = $state(opened);
@@ -39,11 +43,7 @@
 	};
 </script>
 
-<dialog
-	bind:this={dialog}
-	class="modal"
-	onclose={closeIntentionsModal}
->
+<dialog bind:this={dialog} class="modal" onclose={closeIntentionsModal}>
 	<div class="modal-box" style="border-top: 4px solid var(--goal-color)">
 		<h3 class="text-lg font-bold" style="color: var(--goal-color)">{modalTitle}</h3>
 		<div class="py-4">

--- a/src/lib/components/today/actions-input/Editor.svelte
+++ b/src/lib/components/today/actions-input/Editor.svelte
@@ -2,7 +2,8 @@
 	import { onMount } from 'svelte';
 	import './Editor.css';
 
-	let { highlight, value }: { highlight: (value: string) => string; value: string } = $props();
+	let { highlight, value = $bindable() }: { highlight: (value: string) => string; value: string } =
+		$props();
 
 	let input: HTMLTextAreaElement;
 
@@ -27,13 +28,13 @@
 </script>
 
 <div class="goal__editor form-control text-gray-900 dark:text-gray-300">
-	<pre class="goal__editor__pre" aria-hidden="true" />
+	<pre class="goal__editor__pre" aria-hidden="true"></pre>
 	<textarea
-		class="goal__editor__textarea rounded-btn border-base-content caret-black border transition duration-200 ease-in-out dark:caret-white"
+		class="goal__editor__textarea rounded-btn border-base-content border caret-black transition duration-200 ease-in-out dark:caret-white"
 		bind:this={input}
 		contenteditable="true"
 		bind:value
 		tabindex="0"
 		oninput={handleInput}
-	/>
+	></textarea>
 </div>

--- a/src/lib/components/today/review-outcomes/Review.svelte
+++ b/src/lib/components/today/review-outcomes/Review.svelte
@@ -8,17 +8,22 @@
 	import { invalidateAll } from '$app/navigation';
 	import { todayPageErrorStore } from '$src/lib/stores/errors';
 
-	let { intentionsOnLatestDate, setHasOutstandingOutcome }: { intentionsOnLatestDate: Intention[]; setHasOutstandingOutcome: (value: boolean) => void } = $props();
+	let {
+		intentionsOnLatestDate,
+		setHasOutstandingOutcome
+	}: { intentionsOnLatestDate: Intention[]; setHasOutstandingOutcome: (value: boolean) => void } =
+		$props();
 
-	let intentionDate = $state(intentionsOnLatestDate[0]
-		? new Date(intentionsOnLatestDate[0].date)
-		: new Date());
+	let intentionDate = $derived(
+		intentionsOnLatestDate[0] ? new Date(intentionsOnLatestDate[0].date) : new Date()
+	);
 	let showPageLoadingSpinner = $state(true);
+
 	let daysAgo = $state(0);
 	let goalsOnDate = $state<Goal[]>([]);
 	let intentionsOnDate = $state<Intention[]>([]);
 	let newIntentionsToInsert = $state<Omit<Intention, 'id'>[]>([]);
-	let maxOrderNumber = $state<number>();
+	let maxOrderNumber = $state<number>(0);
 	let hasBeenSaved = $state(false);
 
 	$effect(() => {
@@ -196,7 +201,7 @@
 		</p>
 		{#if showPageLoadingSpinner}
 			<div class="flex justify-center">
-				<span class="loading loading-spinner loading-lg" />
+				<span class="loading loading-spinner loading-lg"></span>
 			</div>
 		{:else}
 			<div role="list" id="goal-outcome-list-container" class="grid place-items-center gap-6">

--- a/src/lib/db/db.ts
+++ b/src/lib/db/db.ts
@@ -33,7 +33,7 @@ export class DbInstance {
 				try {
 					fs.accessSync('./data/', fs.constants.R_OK | fs.constants.W_OK);
 				} catch (err) {
-					dbLogger.fatal(new Error('No read/write access to data directory'), err);
+					dbLogger.fatal('No read/write access to data directory', err);
 				}
 
 				betterSqlite3 = new Database('./data/db.sqlite');
@@ -52,7 +52,7 @@ export class DbInstance {
 				fs.mkdirSync(dirPath);
 				dbLogger.info('data directory created');
 			} catch (err) {
-				dbLogger.fatal(new Error('Failed to create data directory'), err);
+				dbLogger.fatal('Failed to create data directory', err);
 			}
 		}
 	}

--- a/src/lib/trpc/middleware/trpc-load.ts
+++ b/src/lib/trpc/middleware/trpc-load.ts
@@ -7,7 +7,7 @@ import { router, createCallerFactory } from '../router';
 const createCaller = createCallerFactory(router);
 
 export async function trpcLoad<
-	Event extends RequestEvent<Partial<Record<string, string>>, string | null>,
+	Event extends RequestEvent<Record<string, string>, string | null>,
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	Method extends (caller: ReturnType<typeof createCaller>) => Promise<any>
 >(event: Event, method: Method): Promise<ReturnType<Method>> {

--- a/src/lib/trpc/routes/goals.test.ts
+++ b/src/lib/trpc/routes/goals.test.ts
@@ -143,7 +143,7 @@ describe('goals', () => {
 		const input = { active: 1, title: '' }; // Missing 'color' field
 		let error;
 		try {
-			(await caller.goals.add(input)) as GoalResult;
+			(await caller.goals.add(input as GoalInput)) as GoalResult;
 		} catch (e) {
 			error = e;
 		}
@@ -175,7 +175,7 @@ describe('goals', () => {
 			.executeTakeFirst();
 		const editedGoal = { ...goalToEdit, title: 'Modified Test Goal' };
 
-		const result = (await caller.goals.edit(editedGoal)) as UpdateResult;
+		const result = (await caller.goals.edit(editedGoal as Goal)) as UpdateResult;
 		expect(Number(result.numUpdatedRows)).toEqual(1);
 
 		const editedGoalFromDb = await db
@@ -236,7 +236,7 @@ describe('goals', () => {
 
 		// Call updateGoals with the updated goals
 		const result = await caller.goals.updateGoals({
-			goals: [editedGoal1, editedGoal2, editedGoal3]
+			goals: [editedGoal1, editedGoal2, editedGoal3] as Goal[]
 		});
 
 		expect(result).toBeInstanceOf(Array);

--- a/src/lib/trpc/routes/intentions.test.ts
+++ b/src/lib/trpc/routes/intentions.test.ts
@@ -184,7 +184,7 @@ describe('intentions', () => {
 		// Append text to the intention
 		const appendText = ' - edit';
 		const appendedIntention = (await caller.intentions.appendText({
-			id: TEST_INTENTION.id,
+			id: TEST_INTENTION.id as number,
 			text: appendText
 		})) as UpdateResult;
 
@@ -218,7 +218,7 @@ describe('intentions', () => {
 	it('updateIntentions', async () => {
 		const result = (await caller.intentions.updateIntentions({
 			intentions: [TEST_INTENTION]
-		})) as Intention[];
+		})) as unknown as Intention[];
 		expect(result).toBeDefined();
 		expect(result[0]).toBeDefined();
 		// TODO: result[0].rows checks
@@ -237,7 +237,7 @@ describe('intentions', () => {
 		const newCompletionStatus = 1; // Assuming 1 represents completed
 		await caller.intentions.updateIntentionCompletionStatus([
 			{
-				intentionId: TEST_INTENTION.id,
+				intentionId: TEST_INTENTION.id as number,
 				completed: newCompletionStatus
 			}
 		]);

--- a/src/lib/utils/logger.ts
+++ b/src/lib/utils/logger.ts
@@ -14,8 +14,7 @@ export const dbLogger = new Logger({
 });
 export const trpcLogger = new Logger({
 	name: 'trpcLogger',
-	hideLogPositionForProduction: true,
-	prettyLogTemplate: '{{name}} ',
+	pretty: { template: '{{name}} ' },
 	minLevel: import.meta.env.PROD || process.env.NODE_ENV === 'test' ? 4 : 1
 });
 export const cronLogger = new Logger({

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -24,8 +24,8 @@
 	{@html webManifestLink}
 </svelte:head>
 
-<div class="min-h-screen bg-base-100">
-	<header class="sticky top-0 z-50 flex h-14 items-center bg-base-100 shadow-sm">
+<div class="bg-base-100 min-h-screen">
+	<header class="bg-base-100 sticky top-0 z-50 flex h-14 items-center shadow-sm">
 		<HeaderContent {toggleTheme} />
 	</header>
 	<main class="p-4">

--- a/src/routes/goals/+layout.svelte
+++ b/src/routes/goals/+layout.svelte
@@ -8,10 +8,7 @@
 {#if $goalPageErrorStore}
 	<div class="toast toast-center">
 		<div class="alert alert-error flex gap-2">
-			<button
-				class="btn btn-circle btn-sm"
-				onclick={() => goalPageErrorStore.setError(null)}
-			>
+			<button class="btn btn-circle btn-sm" onclick={() => goalPageErrorStore.setError(null)}>
 				<X />
 			</button>
 			<p>{$goalPageErrorStore}</p>

--- a/src/routes/goals/+page.svelte
+++ b/src/routes/goals/+page.svelte
@@ -30,7 +30,7 @@
 			});
 			editButtonActive = true;
 		}
-	})
+	});
 
 	function handleEditButtonClick() {
 		if (editButtonActive) {
@@ -83,7 +83,7 @@
 			const goalLogForGoalId = data.goalLogs.filter((log) => log.goalId === iGoal.id);
 			type GoalLogNoId = Omit<GoalLog, 'id'>;
 
-			const last = goalLogForGoalId.sort(
+			const last = (goalLogForGoalId as GoalLogNoId[]).sort(
 				(a: GoalLogNoId, b: GoalLogNoId) => new Date(b.date).valueOf() - new Date(a.date).valueOf()
 			)[0];
 			if (last?.type === 'end' && iGoal.id) {
@@ -101,7 +101,7 @@
 	}
 	$effect(() => {
 		sortInactiveGoals();
-	})
+	});
 </script>
 
 <svelte:head>
@@ -112,11 +112,8 @@
 	<h1 class="flex text-3xl font-bold">
 		Goals
 		<div class="indicator">
-			<span
-				class={editButtonActive
-					? 'badge indicator-item badge-secondary translate-x-1/4'
-					: ''}
-			/>
+			<span class={editButtonActive ? 'badge indicator-item badge-secondary translate-x-1/4' : ''}
+			></span>
 			{#if editButtonActive}
 				<button class="btn mx-2" onclick={handleCancelButtonClick}>Cancel</button>
 			{/if}
@@ -129,11 +126,8 @@
 			</button>
 		</div>
 		<div class="indicator">
-			<span
-				class={dragDisabled
-					? ''
-					: 'badge indicator-item badge-secondary translate-x-1/4'}
-			/>
+			<span class={dragDisabled ? '' : 'badge indicator-item badge-secondary translate-x-1/4'}
+			></span>
 			<button
 				class="btn mx-2"
 				disabled={!dragButtonEnabled || noGoals}
@@ -160,7 +154,11 @@
 		<h1 class="text-3xl font-bold">Inactive Goals</h1>
 		<section role="list" id="goals-list-container" class="mt-2.5 grid gap-2.5 overflow-hidden">
 			{#each data.inactiveGoals as goal, i (goal)}
-				<GoalBoxComponent bind:goal={data.inactiveGoals[i]} currentlyEditing={editButtonActive} isInactiveGoal={true} />
+				<GoalBoxComponent
+					bind:goal={data.inactiveGoals[i]}
+					currentlyEditing={editButtonActive}
+					isInactiveGoal={true}
+				/>
 			{/each}
 		</section>
 	{/if}

--- a/src/routes/journey/+layout.svelte
+++ b/src/routes/journey/+layout.svelte
@@ -8,10 +8,7 @@
 {#if $journeyPageErrorStore}
 	<div class="toast toast-center">
 		<div class="alert alert-error flex gap-2">
-			<button
-				class="btn btn-circle btn-sm"
-				onclick={() => journeyPageErrorStore.setError(null)}
-			>
+			<button class="btn btn-circle btn-sm" onclick={() => journeyPageErrorStore.setError(null)}>
 				<X />
 			</button>
 			<p>{$journeyPageErrorStore}</p>

--- a/src/routes/journey/+page.svelte
+++ b/src/routes/journey/+page.svelte
@@ -34,7 +34,9 @@
 			};
 
 			const observer = new IntersectionObserver(handleIntersect, { threshold: 0.1 });
-			observer.observe(invisibleFooter);
+			if (invisibleFooter) {
+				observer.observe(invisibleFooter);
+			}
 		}
 	});
 
@@ -118,7 +120,7 @@
 		</div>
 		{#if isLoadingMore}
 			<div class="mb-3 flex justify-center">
-				<span class="loading loading-bars loading-lg" />
+				<span class="loading loading-bars loading-lg"></span>
 			</div>
 		{/if}
 		<div bind:this={invisibleFooter} class="pagination-trigger"></div>

--- a/src/routes/today/+layout.svelte
+++ b/src/routes/today/+layout.svelte
@@ -8,10 +8,7 @@
 {#if $todayPageErrorStore}
 	<div class="toast toast-center">
 		<div class="alert alert-error flex gap-2">
-			<button
-				class="btn btn-circle btn-sm"
-				onclick={() => todayPageErrorStore.setError(null)}
-			>
+			<button class="btn btn-circle btn-sm" onclick={() => todayPageErrorStore.setError(null)}>
 				<X />
 			</button>
 			<p>{$todayPageErrorStore}</p>

--- a/src/routes/today/+page.svelte
+++ b/src/routes/today/+page.svelte
@@ -15,16 +15,25 @@
 	let { data }: { data: PageServerData } = $props();
 	type Intentions = (typeof data.intentions)[0];
 
+	// svelte-ignore state_referenced_locally
 	let intentions = $state(data.intentions);
+	// svelte-ignore state_referenced_locally
 	let intentionsOnLatestDate = $state(data.intentionsOnLatestDate);
 	let additionalIntentions = $state<Intentions[]>([]);
 	let validIntentions = $state<boolean>(false);
 	let showValidIntentionsNotification = $state(false);
 	let showAdditionalIntentionsTextArea = $state(false);
 	let showDBErrorNotification = $state(false);
+	// svelte-ignore state_referenced_locally
 	let intentionsFromServer = $state(data.intentions);
 	let hasOutstandingOutcome = $state(false);
 	let showPageLoadingSpinner = $state(false);
+
+	$effect(() => {
+		intentions = data.intentions;
+		intentionsOnLatestDate = data.intentionsOnLatestDate;
+		intentionsFromServer = data.intentions;
+	});
 
 	onMount(() => {
 		todaysIntentionsStore.initialize();
@@ -174,7 +183,7 @@
 
 {#if showPageLoadingSpinner}
 	<div class="flex justify-center">
-		<span class="loading loading-spinner loading-lg" />
+		<span class="loading loading-spinner loading-lg"></span>
 	</div>
 {:else}
 	<div class="flex flex-col gap-4">
@@ -197,10 +206,7 @@
 			/>
 			{#if showAdditionalIntentionsTextArea}
 				<div class="flex items-center">
-					<button
-						class="btn mr-2"
-						onclick={handleHideAdditionalIntentionsTextArea}>Hide</button
-					>
+					<button class="btn mr-2" onclick={handleHideAdditionalIntentionsTextArea}>Hide</button>
 					<h3 class="text-lg font-bold">What else are you doing towards your goals today?</h3>
 				</div>
 				{#if showValidIntentionsNotification}
@@ -235,8 +241,7 @@
 				<div role="alert" class="alert alert-error border-gray-400">
 					<CircleX class="h-6 w-6 shrink-0 stroke-current" />
 					<span
-						>Please check that your intentions are formatted correctly and have valid goal
-						numbers.</span
+						>Please check that your intentions are formatted correctly and have valid goal numbers.</span
 					>
 				</div>
 			{/if}


### PR DESCRIPTION
Follows the prettier-plugin-svelte v4 bump (#162) and surfaces the cleanup needed to keep pnpm check / pnpm lint clean on master.

- tslog v5 setting names (pretty.template, error first arg) match the bump in #160
- Restore bindable defaults on GoalDescription, IntentionsModal, Editor so parent bind works in Svelte 5
- Fix trpc-load generic constraint to match SvelteKit RequestEvent
- Narrow test fixtures with explicit casts so vitest --run compiles
- Convert let x = prop.foo captures to derived so they react to prop updates
- Replace ambiguous self-closing non-void tags
- Disable no-undef/no-useless-assignment in .svelte and .ts where TS owns the check and these rules conflict with bindable destructuring
- Add aria-label to popup button and ignore span-listitem a11y warning