### PR TITLE
fix: get vitest unit tests passing again

### DIFF
--- a/src/lib/db/migrate-to-latest.ts
+++ b/src/lib/db/migrate-to-latest.ts
@@ -5,7 +5,8 @@ import { dbLogger } from '$src/lib/utils/logger';
 import { DbInstance } from './db';
 
 export async function migrateToLatest(db?: Kysely<DB>, migrationName?: string) {
-	if (process.env.NODE_ENV !== 'test') {
+	const isTest = process.env.NODE_ENV === 'test';
+	if (!isTest && process.env.NODE_ENV !== 'migration') {
 		process.env.NODE_ENV = 'migration';
 	}
 	db = db || DbInstance.getInstance().db;
@@ -44,27 +45,30 @@ export async function migrateToLatest(db?: Kysely<DB>, migrationName?: string) {
 			console.error(`failed to execute migration "${it.migrationName}"`);
 		}
 	});
-	if (results?.length === 0) {
+	if (!results || results.length === 0) {
 		dbLogger.info('No new migrations to run.');
 	} else {
-		dbLogger.info(`Ran ${results?.length} migrations`);
+		dbLogger.info(`Ran ${results.length} migrations`);
 	}
 
 	if (error) {
 		console.error('failed to migrate');
 		console.error(error);
-		if (process.env.NODE_ENV !== 'test') {
+		if (!isTest) {
 			process.exit(1);
 		}
 	}
 
-	if (process.env.NODE_ENV !== 'test') {
+	if (!isTest) {
 		await db.destroy();
 	}
 }
 
-if (process.argv[2] === '--migration') {
-	migrateToLatest(undefined, process.argv[3]);
-} else {
-	migrateToLatest();
+// Run as a CLI only when invoked directly (e.g. `vite-node ./src/lib/db/migrate-to-latest.ts`).
+// Imports by tests / app code must not trigger a module-level migration, which was destroying
+// the DbInstance singleton's driver before tests could run their beforeEach setup.
+const isMainModule = import.meta.url === `file://${process.argv[1]}`;
+if (isMainModule) {
+	const migrationName = process.argv[2] === '--migration' ? process.argv[3] : undefined;
+	migrateToLatest(undefined, migrationName);
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,10 @@ const config = {
 	],
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}'],
-		reporters: [['default', { summary: false }]]
+		reporters: [['default', { summary: false }]],
+		env: {
+			NODE_ENV: 'test'
+		}
 	}
 };
 


### PR DESCRIPTION
Two problems were breaking pnpm vitest --run:

1. migrate-to-latest.ts ran its module body on every import. When imported by a test, it called migrateToLatest() with no args, walked the singleton DbInstance, and destroyed its driver before beforeEach had a chance to set up its own in-memory db. Subsequent tests then ran against a Kysely whose underlying better-sqlite3 connection was gone (driver has already been destroyed).

Guard the CLI invocation with import.meta.url === file://argv[1], matching the standard Node CLI-detect pattern. Tests and app code now only get the exported migrateToLatest function.

2. Vitest was inheriting NODE_ENV from the parent shell (production on this workstation) instead of setting NODE_ENV=test. The migrateToLatest function relied on NODE_ENV === 'test' to skip its process.exit(1) and db.destroy() paths.

Set test.env.NODE_ENV = 'test' in vite.config.ts so the test runner always runs in test mode regardless of how it was invoked.

Result: 31 tests pass, 1 todo, 0 failures. pnpm check, pnpm lint, pnpm build all still green.